### PR TITLE
Fixed unit tests and added tests for headers

### DIFF
--- a/RAMLSharp.Test/RamlMapperHeaderTests.cs
+++ b/RAMLSharp.Test/RamlMapperHeaderTests.cs
@@ -1,0 +1,269 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using RAMLSharp.Attributes;
+using RAMLSharp.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Web.Http.Controllers;
+using System.Web.Http.Description;
+
+namespace RAMLSharp.Test
+{
+    [TestClass]
+    [ExcludeFromCodeCoverage]
+    public class RamlMapperHeaderTests
+    {
+        RAMLModel expectedModel = null;
+        IEnumerable<ApiDescription> descriptions = null;
+        Mock<HttpActionDescriptor> mockActionDescriptor = null;
+        List<RequestHeaderModel> expectedHeader = null;
+        Collection<RequestHeadersAttribute> expectedHeaderAttributes = null;
+        
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            mockActionDescriptor = new Mock<HttpActionDescriptor>();
+
+            expectedModel = new RAMLModel
+            {
+                BaseUri = new Uri("http://www.test.com"),
+                DefaultMediaType = "application/json",
+                Description = "test",
+                Title = "test",
+                Version = "1",
+                Routes = new List<RouteModel>
+                { 
+                    new RouteModel
+                    { 
+                        UrlTemplate="api/test", 
+                        Verb="get",
+                        Headers = null
+                    } 
+                }
+            };
+
+            descriptions = new List<ApiDescription>()
+            {
+                new ApiDescription
+                {
+                     HttpMethod = new System.Net.Http.HttpMethod("get"),
+                     RelativePath = "api/test",
+                     ActionDescriptor = mockActionDescriptor.Object
+                }
+            };
+
+            expectedHeader = new List<RequestHeaderModel>
+            {
+                new RequestHeaderModel {
+                    Name = "Accept",
+                    Description = "Used to tell the server what format it will accept.",
+                    Example = "application/json",
+                    IsRequired = false,
+                    Type = typeof(string)
+                },
+                new RequestHeaderModel {
+                    Name = "Date",
+                    Description = "Used to tell the server when the request was made.",
+                    Example = "application/json",
+                    IsRequired = false,
+                    Type = typeof(DateTime)
+                }
+            };
+
+            expectedHeaderAttributes = new Collection<RequestHeadersAttribute>(
+                    expectedHeader.Select(
+                    p => new RequestHeadersAttribute
+                    {
+                        Name = p.Name,
+                        Description = p.Description,
+                        Example = p.Example,
+                        IsRequired = p.IsRequired,
+                        Type = p.Type
+                    }
+                ).ToList());
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithOneHeader_Display1Headers()
+        {
+            expectedModel.Routes[0].Headers = new List<RequestHeaderModel>
+            {
+                expectedHeader[0]
+            };
+            var headerAttribute = new Collection<RequestHeadersAttribute>
+            {
+                expectedHeaderAttributes[0]
+            };
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(headerAttribute);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.IsTrue(result.ToString().Contains("headers:"));
+            Assert.IsTrue(result.ToString().Contains("Accept:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithNullHeader_DoNotDisplayHeadersSection()
+        {
+            expectedModel.Routes[0].Headers = null;
+            Collection<RequestHeadersAttribute> headerAttributes = null;
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(headerAttributes);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.IsFalse(result.ToString().Contains("headers:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithMultipleHeaders_Display2Headers()
+        {
+            expectedModel.Routes[0].Headers = expectedHeader;
+
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(expectedHeaderAttributes);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.IsTrue(result.ToString().Contains("headers:"));
+            Assert.IsTrue(result.ToString().Contains("Accept:"));
+            Assert.IsTrue(result.ToString().Contains("Date:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithNullName_DoNotDisplayHeaderSection()
+        {
+            expectedHeader[0].Name = null;
+            expectedHeaderAttributes[0].Name = null;
+
+            expectedModel.Routes[0].Headers = new List<RequestHeaderModel>
+            {
+                expectedHeader[0]
+            };
+            var headerAttribute = new Collection<RequestHeadersAttribute>
+            {
+                expectedHeaderAttributes[0]
+            };
+
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(headerAttribute);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.IsFalse(result.ToString().Contains("headers:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithTwoNullName_DoNotDisplayHeaderSection()
+        {
+            expectedHeader[0].Name = null;
+            expectedHeader[1].Name = null;
+            expectedModel.Routes[0].Headers = expectedHeader;
+
+            expectedHeaderAttributes[0].Name = null;
+            expectedHeaderAttributes[1].Name = null;
+            
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(expectedHeaderAttributes);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.IsFalse(result.ToString().Contains("headers:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithNullDescription_DoNotDisplayDescriptionField()
+        {
+            expectedHeader[0].Description = null;
+            expectedHeaderAttributes[0].Description = null;
+
+            expectedModel.Routes[0].Headers = new List<RequestHeaderModel>
+            {
+                expectedHeader[0]
+            };
+            var headerAttribute = new Collection<RequestHeadersAttribute>
+            {
+                expectedHeaderAttributes[0]
+            };
+
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(headerAttribute);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            var r = result.ToString();
+            Assert.IsTrue(result.ToString().Contains("headers:"));
+            Assert.IsFalse(result.ToString().Contains("        description:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithNullExample_DoNotDisplayExampleField()
+        {
+            expectedHeader[0].Example = null;
+            expectedHeaderAttributes[0].Example = null;
+
+            expectedModel.Routes[0].Headers = new List<RequestHeaderModel>
+            {
+                expectedHeader[0]
+            };
+            var headerAttribute = new Collection<RequestHeadersAttribute>
+            {
+                expectedHeaderAttributes[0]
+            };
+
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(headerAttribute);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            var r = result.ToString();
+            Assert.IsTrue(result.ToString().Contains("headers:"));
+            Assert.IsFalse(result.ToString().Contains("        example:"));
+        }
+
+        [TestMethod]
+        public void RamlMapper_CreateOneApiWithNullType_DoNotDisplayTypeField()
+        {
+            expectedHeader[0].Type = null;
+            expectedHeaderAttributes[0].Type = null;
+
+            expectedModel.Routes[0].Headers = new List<RequestHeaderModel>
+            {
+                expectedHeader[0]
+            };
+            var headerAttribute = new Collection<RequestHeadersAttribute>
+            {
+                expectedHeaderAttributes[0]
+            };
+
+            mockActionDescriptor.Setup(p => p.GetCustomAttributes<RequestHeadersAttribute>())
+                                .Returns(headerAttribute);
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            var r = result.ToString();
+            Assert.IsTrue(result.ToString().Contains("headers:"));
+            Assert.IsFalse(result.ToString().Contains("        type:"));
+        }
+    }
+}

--- a/RAMLSharp.Test/RamlMapperTests.cs
+++ b/RAMLSharp.Test/RamlMapperTests.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Web.Http.Routing;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Web.Http.Description;
-using Moq;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RAMLSharp.Models;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Web.Http.Description;
 
 namespace RAMLSharp.Test
 {
@@ -13,11 +11,12 @@ namespace RAMLSharp.Test
     [ExcludeFromCodeCoverage]
     public class RamlMapperTests
     {
-        #region null checks for base information
-        [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNullAPIs()
+        RAMLModel expectedModel = null;
+
+        [TestInitialize]
+        public void TestInitialize()
         {
-            var expected = new RAMLModel
+            expectedModel = new RAMLModel
             {
                 BaseUri = new Uri("http://www.test.com"),
                 DefaultMediaType = "application/json",
@@ -26,133 +25,93 @@ namespace RAMLSharp.Test
                 Version = "1",
                 Routes = new List<RouteModel>()
             };
-            IEnumerable<ApiDescription> model = null;
+        }
 
-            var subject = new RAMLMapper(model);
+        #region null checks for base information
+        [TestMethod]
+        public void RAMLSharp_CreateRamlDocumentWithNullAPIs_DisplayBasicRAMLDocument()
+        {
+            IEnumerable<ApiDescription> modelApiDescription = null;
+
+            var subject = new RAMLMapper(modelApiDescription);
             var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNoAPIs()
+        public void RAMLSharp_CreateRamlDocumentWithNoAPIs_DisplayBasicRAMLDocument()
         {
-            var expected = new RAMLModel
-            {
-                BaseUri = new Uri("http://www.test.com"),
-                DefaultMediaType = "application/json",
-                Description = "test",
-                Title = "test",
-                Version = "1"
-            };
-            var model = new List<ApiDescription>();
+            expectedModel.Routes = null;
+            var modelApiDescription = new List<ApiDescription>();
 
-            var subject = new RAMLMapper(model);
+            var subject = new RAMLMapper(modelApiDescription);
             var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNullUri()
+        public void RAMLSharp_CreateRamlDocumentWithNullUri_DisplayBasicRAMLDocumentWithoutURI()
         {
-            Uri expectedUri = null;
-            var expected = new RAMLModel
-            {
-                BaseUri = expectedUri,
-                DefaultMediaType = "application/json",
-                Description = "test",
-                Title = "test",
-                Version = "1"
-            };
+            expectedModel.BaseUri = null;
             var model = new List<ApiDescription>();
 
             var subject = new RAMLMapper(model);
-            var result = subject.WebApiToRamlModel(expectedUri, "test", "1", "application/json", "test");
+            var result = subject.WebApiToRamlModel(expectedModel.BaseUri, "test", "1", "application/json", "test");
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNullTitle()
+        public void RAMLSharp_CreateRamlDocumentWithNullTitle_DisplayBasicRAMLDocumentWithBlankTitle()
         {
-            string expectedTitle = null;
-            var expected = new RAMLModel
-            {
-                BaseUri = new Uri("http://www.test.com"),
-                DefaultMediaType = "application/json",
-                Description = "test",
-                Title = expectedTitle,
-                Version = "1"
-            };
+            expectedModel.Title = null;
             var model = new List<ApiDescription>();
 
             var subject = new RAMLMapper(model);
-            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), expectedTitle, "1", "application/json", "test");
-
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), expectedModel.Title, "1", "application/json", "test");
+            var r = result.ToString();
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.IsTrue(result.ToString().Contains("title:"));
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNullDescription()
+        public void RAMLSharp_CreateRamlDocumentWithNullDescription_DisplayBasicRAMLDocumentWithoutDescription()
         {
-            string expectedDescription = null;
-            var expected = new RAMLModel
-            {
-                BaseUri = new Uri("http://www.test.com"),
-                DefaultMediaType = "application/json",
-                Description = expectedDescription,
-                Title = "test",
-                Version = "1"
-            };
+            expectedModel.Description = null;
             var model = new List<ApiDescription>();
 
             var subject = new RAMLMapper(model);
-            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", expectedDescription);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", expectedModel.Description);
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
             Assert.IsFalse(result.ToString().Contains("content:"));
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNullVersion()
+        public void RAMLSharp_CreateRamlDocumentWithNullVersion_DisplayBasicRAMLDocumentWithoutVersion()
         {
-            string expectedVersion = null;
-            var expected = new RAMLModel
-            {
-                BaseUri = new Uri("http://www.test.com"),
-                DefaultMediaType = "application/json",
-                Description = "test",
-                Title = "test",
-                Version = expectedVersion
-            };
+            expectedModel.Version = null;
             var model = new List<ApiDescription>();
 
             var subject = new RAMLMapper(model);
-            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", expectedVersion, "application/json", "test");
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", expectedModel.Version, "application/json", "test");
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
             Assert.IsFalse(result.ToString().Contains("version:"));
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithNullBaseMediaType()
+        public void RAMLSharp_CreateRamlDocumentWithNullBaseMediaType_DisplayBasicRAMLDocumentWithoutMediaType()
         {
-            string expectedBaseMediaType = null;
-            var expected = new RAMLModel
-            {
-                BaseUri = new Uri("http://www.test.com"),
-                DefaultMediaType = expectedBaseMediaType,
-                Description = "test",
-                Title = "test",
-                Version = "1"
-            };
+            expectedModel.DefaultMediaType = null;
             var model = new List<ApiDescription>();
 
             var subject = new RAMLMapper(model);
-            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", expectedBaseMediaType, "test");
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", expectedModel.DefaultMediaType, "test");
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
             Assert.IsFalse(result.ToString().Contains("mediaType:"));
         }
 
@@ -160,7 +119,7 @@ namespace RAMLSharp.Test
 
         #region check for fields in base information
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithVersion()
+        public void RAMLSharp_CreateRamlDocumentWithVersion_GenerateRAMLWithVersion()
         {
             IEnumerable<ApiDescription> model = null;
 
@@ -171,7 +130,7 @@ namespace RAMLSharp.Test
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithBaseMediaType()
+        public void RAMLSharp_CreateRamlDocumentWithBaseMediaType_GenerateRAMLWithMediaType()
         {
             IEnumerable<ApiDescription> model = null;
 
@@ -182,7 +141,7 @@ namespace RAMLSharp.Test
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithDescription()
+        public void RAMLSharp_CreateRamlDocumentWithDescription_GenerateRAMLWithDescription()
         {
             IEnumerable<ApiDescription> model = null;
 
@@ -193,7 +152,7 @@ namespace RAMLSharp.Test
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithTitle()
+        public void RAMLSharp_CreateRamlDocumentWithTitle_GenerateRAMLWithTitle()
         {
             IEnumerable<ApiDescription> model = null;
 
@@ -204,7 +163,7 @@ namespace RAMLSharp.Test
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithUri()
+        public void RAMLSharp_CreateRamlDocumentWithUri_GenerateRAMLWithBaseURI()
         {
             IEnumerable<ApiDescription> model = null;
 
@@ -215,7 +174,7 @@ namespace RAMLSharp.Test
         }
 
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithProtocol()
+        public void RAMLSharp_CreateRamlDocumentWithProtocol_GenerateRAMLWithProtocol()
         {
             IEnumerable<ApiDescription> model = null;
 
@@ -228,24 +187,17 @@ namespace RAMLSharp.Test
 
         #region ApiDescription Tests
         [TestMethod]
-        public void RAMLSharp_CreateRamlDocumentWithOneApi()
+        public void RAMLSharp_CreateRamlDocumentWithOneApi_GenerateRAMLWithOneAPI()
         {
-            var expected = new RAMLModel
-            {
-                BaseUri = new Uri("http://www.test.com"),
-                DefaultMediaType = "application/json",
-                Description = "test",
-                Title = "test",
-                Version = "1",
-                Routes = new List<RouteModel>
+            expectedModel.Routes = new List<RouteModel>
+            { 
+                new RouteModel
                 { 
-                    new RouteModel
-                    { 
-                        UrlTemplate="api/test", 
-                        Verb="get" 
-                    } 
-                }
+                    UrlTemplate="api/test", 
+                    Verb="get" 
+                } 
             };
+            
             IEnumerable<ApiDescription> model = new List<ApiDescription>()
             {
                 new ApiDescription
@@ -258,7 +210,7 @@ namespace RAMLSharp.Test
             var subject = new RAMLMapper(model);
             var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
 
-            Assert.AreEqual(expected.ToString(), result.ToString(), "The RAML string must be the same.");
+            Assert.AreEqual(expectedModel.ToString(), result.ToString(), "The RAML string must be the same.");
         }
         #endregion
     }

--- a/RAMLSharp.Test/RamlSharp.Test.csproj
+++ b/RAMLSharp.Test/RamlSharp.Test.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RamlMapperTests.cs" />
     <Compile Include="TypeExtensionsTest.cs" />
+    <Compile Include="RamlMapperHeaderTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\RamlSharp\RamlSharp.csproj">

--- a/RAMLSharp.Test/TypeExtensionsTest.cs
+++ b/RAMLSharp.Test/TypeExtensionsTest.cs
@@ -10,43 +10,43 @@ namespace RAMLSharp.Test
     {
         #region integer tests
         [TestMethod]
-        public void TypeExtensions_Int32()
+        public void TypeExtensions_Int32_ReturnsInteger()
         {
             Assert.AreEqual(typeof(Int32).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_SByte()
+        public void TypeExtensions_SByte_ReturnsInteger()
         {
             Assert.AreEqual(typeof(SByte).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_UInt16()
+        public void TypeExtensions_UInt16_ReturnsInteger()
         {
             Assert.AreEqual(typeof(UInt16).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_UInt32()
+        public void TypeExtensions_UInt32_ReturnsInteger()
         {
             Assert.AreEqual(typeof(UInt32).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_UInt64()
+        public void TypeExtensions_UInt64_ReturnsInteger()
         {
             Assert.AreEqual(typeof(UInt64).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_Int16()
+        public void TypeExtensions_Int16_ReturnsInteger()
         {
             Assert.AreEqual(typeof(Int16).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_Int64()
+        public void TypeExtensions_Int64_ReturnsInteger()
         {
             Assert.AreEqual(typeof(Int64).ToRamlType(), "integer", "The return string should be 'integer'.");
         }
@@ -54,19 +54,19 @@ namespace RAMLSharp.Test
 
         #region number tests
         [TestMethod]
-        public void TypeExtensions_Decimal()
+        public void TypeExtensions_Decimal_ReturnsNumber()
         {
             Assert.AreEqual(typeof(Decimal).ToRamlType(), "number", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_Double()
+        public void TypeExtensions_Double_ReturnsNumber()
         {
             Assert.AreEqual(typeof(Double).ToRamlType(), "number", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_Single()
+        public void TypeExtensions_Single_ReturnsNumber()
         {
             Assert.AreEqual(typeof(Single).ToRamlType(), "number", "The return string should be 'integer'.");
         }
@@ -74,7 +74,7 @@ namespace RAMLSharp.Test
 
         #region boolean tests
         [TestMethod]
-        public void TypeExtensions_Boolean()
+        public void TypeExtensions_Boolean_ReturnsBoolean()
         {
             Assert.AreEqual(typeof(Boolean).ToRamlType(), "boolean", "The return string should be 'integer'.");
         }
@@ -82,7 +82,7 @@ namespace RAMLSharp.Test
 
         #region date tests
         [TestMethod]
-        public void TypeExtensions_DateTime()
+        public void TypeExtensions_DateTime_ReturnsDate()
         {
             Assert.AreEqual(typeof(DateTime).ToRamlType(), "date", "The return string should be 'integer'.");
         }
@@ -90,13 +90,13 @@ namespace RAMLSharp.Test
 
         #region string tests
         [TestMethod]
-        public void TypeExtensions_string()
+        public void TypeExtensions_string_ReturnsString()
         {
             Assert.AreEqual(typeof(string).ToRamlType(), "string", "The return string should be 'integer'.");
         }
 
         [TestMethod]
-        public void TypeExtensions_object()
+        public void TypeExtensions_object_ReturnsString()
         {
             Assert.AreEqual(typeof(object).ToRamlType(), "string", "The return string should be 'integer'.");
         }

--- a/RAMLSharp/Models/RamlModel.cs
+++ b/RAMLSharp/Models/RamlModel.cs
@@ -127,7 +127,9 @@ namespace RAMLSharp.Models
 
         private StringBuilder SetHeaders(StringBuilder RAML, RouteModel route)
         {
-            if (route.Headers == null || route.Headers.Count <= 0) return RAML;
+            if (route.Headers == null || 
+                route.Headers.Count <= 0 ||
+                route.Headers.All(p => String.IsNullOrEmpty(p.Name))) return RAML;
             
             RAML.AppendFormat("    headers:{0}", _newLine);
             return route.Headers.Aggregate(RAML, SetHeaderDetails);
@@ -137,10 +139,23 @@ namespace RAMLSharp.Models
         {
             RAML.AppendFormat("      {0}: {1}", header.Name, _newLine);
             RAML.AppendFormat("        displayName: {0}{1}", header.Name, _newLine);
-            RAML.AppendFormat("        example: {0}{1}", header.Example, _newLine);
-            RAML.AppendFormat("        type: {0}{1}", header.Type.ToRamlType(), _newLine);
+
+            if (!String.IsNullOrEmpty(header.Example))
+            {
+                RAML.AppendFormat("        example: {0}{1}", header.Example, _newLine);
+            }
+
+            if (header.Type != null)
+            {
+                RAML.AppendFormat("        type: {0}{1}", header.Type.ToRamlType(), _newLine);
+            }
+
             RAML = SetHeaderMinMax(RAML, header);
-            RAML.AppendFormat("        description: {0}{1}", header.Description, _newLine);
+            if (!String.IsNullOrEmpty(header.Description))
+            {
+                RAML.AppendFormat("        description: {0}{1}", header.Description, _newLine);
+            }
+
             return RAML;
         }
 


### PR DESCRIPTION
Refactored unit tests to add what the return type is.
Refactored unit tests to add a test initializer to reduce recreating the same code.
Added tests for headers section of RAML.