### PR TITLE
Fixed null references on Uri Parameters

### DIFF
--- a/RAMLSharp.Test/UriParameterTests.cs
+++ b/RAMLSharp.Test/UriParameterTests.cs
@@ -190,5 +190,61 @@ namespace RAMLSharp.Test
             Assert.IsTrue(result.ToString().Contains("        type: string"));
             Assert.IsTrue(!result.ToString().Contains("        type: date"));
         }
+
+        [TestMethod]
+        public void UriParameters_ParameterDescriptor_IfPropertyIsNullThenSkip()
+        {
+            var parameterDescriptions = new Collection<ApiParameterDescription>()
+            {
+                sampleApiParameterDescription
+            };
+            sampleDescription = new FakeApiDescription(parameterDescriptions)
+            {
+                HttpMethod = new System.Net.Http.HttpMethod("get"),
+                RelativePath = "api/test"
+            };
+            
+            sampleApiParameterDescription.ParameterDescriptor = null;
+
+            descriptions = new List<ApiDescription>() { sampleDescription };
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+
+            Assert.IsFalse(String.IsNullOrEmpty(result.ToString()));
+        }
+
+
+        [TestMethod]
+        public void UriParameters_ParameterDescriptor_IfTypeIsNullThenSkip()
+        {
+            var parameterDescriptions = new Collection<ApiParameterDescription>()
+            {
+                sampleApiParameterDescription
+            };
+            sampleDescription = new FakeApiDescription(parameterDescriptions)
+            {
+                HttpMethod = new System.Net.Http.HttpMethod("get"),
+                RelativePath = "api/test"
+            };
+
+            mockHttpParameterDescriptor.Setup(p => p.IsOptional)
+                                       .Returns(true);
+            mockHttpParameterDescriptor.Setup(p => p.DefaultValue)
+                                       .Returns(null);
+            mockHttpParameterDescriptor.Setup(p => p.ParameterType)
+                                       .Returns<Type>(null);
+
+            sampleApiParameterDescription.ParameterDescriptor = mockHttpParameterDescriptor.Object;
+
+            descriptions = new List<ApiDescription>() { sampleDescription };
+
+            var subject = new RAMLMapper(descriptions);
+            var result = subject.WebApiToRamlModel(new Uri("http://www.test.com"), "test", "1", "application/json", "test");
+            
+            Assert.IsFalse(String.IsNullOrEmpty(result.ToString()));
+        }
+
+
     }
 }

--- a/RAMLSharp/Properties/AssemblyInfo.cs
+++ b/RAMLSharp/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]

--- a/RAMLSharp/RamlMapper.cs
+++ b/RAMLSharp/RamlMapper.cs
@@ -127,7 +127,10 @@ namespace RAMLSharp
             var result = new List<RequestUriParameterModel>();
 
             var complexParameters = description.ParameterDescriptions
-                    .Where(r => r.Source == ApiParameterSource.FromUri && r.ParameterDescriptor.ParameterType.IsComplexModel())
+                    .Where(r => r.Source == ApiParameterSource.FromUri)
+                    .Where(r => r.ParameterDescriptor != null)
+                    .Where(r => r.ParameterDescriptor.ParameterType != null)
+                    .Where(r => r.ParameterDescriptor.ParameterType.IsComplexModel())
                     .Select(s => new
                     {
                         Properties = s.ParameterDescriptor.ParameterType.GetProperties(),
@@ -151,7 +154,10 @@ namespace RAMLSharp
             };
 
             var notComplexParameters = description.ParameterDescriptions
-                    .Where(r => r.Source == ApiParameterSource.FromUri && !r.ParameterDescriptor.ParameterType.IsComplexModel())
+                    .Where(r => r.Source == ApiParameterSource.FromUri)
+                    .Where(r => r.ParameterDescriptor != null)
+                    .Where(r => r.ParameterDescriptor.ParameterType != null)
+                    .Where(r => !r.ParameterDescriptor.ParameterType.IsComplexModel())
                     .Select(q => new RequestUriParameterModel
                     {
                         Name = q.Name,

--- a/nuget/RamlSharp.nuspec
+++ b/nuget/RamlSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>RamlSharp</id>
-    <version>1.0.2.0</version>
+    <version>1.0.3.0</version>
     <title>RAMLSharp</title>
     <authors>Jorden Lowe, Dominick Aleardi</authors>
     <owners>Quicken Loans</owners>
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Enables WebApi projects to generate their RAML specification.</summary>
     <description>Enables WebApi projects to generate their RAML specification.</description>
-    <releaseNotes>Fixed issue with complex types in URI parameters.  Added xml documenation to the project for intellsense.</releaseNotes>
+    <releaseNotes>Fixed issue with complex types in URI parameters.  Added xml documenation to the project for intellsense.  Fixed Null Reference Exception on URI Parameters.</releaseNotes>
     <copyright>Copyright ©  2015</copyright>
     <tags>webapi raml help pages ramlsharp</tags>
     <dependencies>


### PR DESCRIPTION
If the ParameterDescriptor is null, it will bomb out.  Added tests and code to skip this scenario.