### PR TITLE
Fixed URI duplication

### DIFF
--- a/RAMLSharp.Sample/Controllers/ValuesController.cs
+++ b/RAMLSharp.Sample/Controllers/ValuesController.cs
@@ -102,6 +102,26 @@ namespace RAMLSharp.Sample.Controllers
             };
         }
 
+        [Route("list/{id}")]
+        [HttpGet]
+        public HttpResponseMessage GetSomething1([FromUri]BunchOfFields searchRequest, [FromUri] string id)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("doing something")
+            };
+        }
+
+        [Route("list/{id}")]
+        [HttpPost]
+        public HttpResponseMessage GetSomething2([FromUri]BunchOfFields searchRequest, [FromUri] string id)
+        {
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("doing something")
+            };
+        }
+
         [Route("list2")]
         [HttpGet]
         public HttpResponseMessage GetSomething([FromUri]long? searchRequest)

--- a/RAMLSharp.Test/RamlMapperHeaderTests.cs
+++ b/RAMLSharp.Test/RamlMapperHeaderTests.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Web.Http.Controllers;
 using System.Web.Http.Description;
+using System.Web.Http.Routing;
 
 namespace RAMLSharp.Test
 {
@@ -21,11 +22,14 @@ namespace RAMLSharp.Test
         Mock<HttpActionDescriptor> mockActionDescriptor = null;
         List<RequestHeaderModel> expectedHeader = null;
         Collection<RequestHeadersAttribute> expectedHeaderAttributes = null;
+        Mock<IHttpRoute> mockRoute = null;
         
         [TestInitialize]
         public void TestInitialize()
         {
             mockActionDescriptor = new Mock<HttpActionDescriptor>();
+            mockRoute = new Mock<IHttpRoute>();
+            mockRoute.Setup(p => p.RouteTemplate).Returns("api/test");
 
             expectedModel = new RAMLModel
             {
@@ -51,7 +55,8 @@ namespace RAMLSharp.Test
                 {
                      HttpMethod = new System.Net.Http.HttpMethod("get"),
                      RelativePath = "api/test",
-                     ActionDescriptor = mockActionDescriptor.Object
+                     ActionDescriptor = mockActionDescriptor.Object,
+                     Route = mockRoute.Object
                 }
             };
 

--- a/RAMLSharp.Test/RamlMapperResponseBodyTests.cs
+++ b/RAMLSharp.Test/RamlMapperResponseBodyTests.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.Web.Http.Controllers;
 using System.Web.Http.Description;
 using System.Diagnostics.CodeAnalysis;
+using System.Web.Http.Routing;
 
 namespace RAMLSharp.Test
 {
@@ -21,11 +22,14 @@ namespace RAMLSharp.Test
         Mock<HttpActionDescriptor> mockActionDescriptor = null;
         List<ResponseModel> expectedResponseBody = null;
         Collection<ResponseBodyAttribute> expectedResponseBodyAttributes = null;
+        Mock<IHttpRoute> mockRoute = null;
 
         [TestInitialize]
         public void TestInitialize()
         {
             mockActionDescriptor = new Mock<HttpActionDescriptor>();
+            mockRoute = new Mock<IHttpRoute>();
+            mockRoute.Setup(p => p.RouteTemplate).Returns("api/test");
 
             expectedModel = new RAMLModel
             {
@@ -51,7 +55,8 @@ namespace RAMLSharp.Test
                 {
                      HttpMethod = new System.Net.Http.HttpMethod("get"),
                      RelativePath = "api/test",
-                     ActionDescriptor = mockActionDescriptor.Object
+                     ActionDescriptor = mockActionDescriptor.Object,
+                     Route = mockRoute.Object
                 }
             };
 

--- a/RAMLSharp.Test/RamlMapperTests.cs
+++ b/RAMLSharp.Test/RamlMapperTests.cs
@@ -1,9 +1,11 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
 using RAMLSharp.Models;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Web.Http.Description;
+using System.Web.Http.Routing;
 
 namespace RAMLSharp.Test
 {
@@ -12,6 +14,7 @@ namespace RAMLSharp.Test
     public class RamlMapperTests
     {
         RAMLModel expectedModel = null;
+        Mock<IHttpRoute> mockRoute = null;
 
         [TestInitialize]
         public void TestInitialize()
@@ -25,6 +28,8 @@ namespace RAMLSharp.Test
                 Version = "1",
                 Routes = new List<RouteModel>()
             };
+            mockRoute = new Mock<IHttpRoute>();
+            mockRoute.Setup(p => p.RouteTemplate).Returns("api/test");
         }
 
         #region null checks for base information
@@ -203,7 +208,8 @@ namespace RAMLSharp.Test
                 new ApiDescription
                 {
                      HttpMethod = new System.Net.Http.HttpMethod("get"),
-                     RelativePath = "api/test"
+                     RelativePath = "api/test",
+                     Route = mockRoute.Object
                 }
             };
 

--- a/RAMLSharp.Test/UriParameterTests.cs
+++ b/RAMLSharp.Test/UriParameterTests.cs
@@ -9,6 +9,7 @@ using System.Web.Http.Controllers;
 using System.Collections.ObjectModel;
 using RAMLSharp.Test.Fakes;
 using System.Diagnostics.CodeAnalysis;
+using System.Web.Http.Routing;
 
 namespace RAMLSharp.Test
 {
@@ -21,11 +22,14 @@ namespace RAMLSharp.Test
         FakeApiDescription sampleDescription = null;
         ApiParameterDescription sampleApiParameterDescription = null;
         Mock<HttpParameterDescriptor> mockHttpParameterDescriptor = null;
+        Mock<IHttpRoute> mockRoute = null;
 
         [TestInitialize]
         public void TestInitialize()
         {
             mockHttpParameterDescriptor = new Mock<HttpParameterDescriptor>();
+            mockRoute = new Mock<IHttpRoute>();
+            mockRoute.Setup(p => p.RouteTemplate).Returns("api/test");
 
             expectedModel = new RAMLModel
             {
@@ -63,7 +67,8 @@ namespace RAMLSharp.Test
             sampleDescription = new FakeApiDescription(parameterDescriptions)
             {
                 HttpMethod = new System.Net.Http.HttpMethod("get"),
-                RelativePath = "api/test"
+                RelativePath = "api/test",
+                Route = mockRoute.Object
             };
 
             mockHttpParameterDescriptor.Setup(p => p.IsOptional)
@@ -98,7 +103,8 @@ namespace RAMLSharp.Test
             sampleDescription = new FakeApiDescription(parameterDescriptions)
             {
                 HttpMethod = new System.Net.Http.HttpMethod("get"),
-                RelativePath = "api/test"
+                RelativePath = "api/test",
+                Route = mockRoute.Object
             };
 
             mockHttpParameterDescriptor.Setup(p => p.IsOptional)
@@ -129,7 +135,8 @@ namespace RAMLSharp.Test
             sampleDescription = new FakeApiDescription(parameterDescriptions)
             {
                 HttpMethod = new System.Net.Http.HttpMethod("get"),
-                RelativePath = "api/test"
+                RelativePath = "api/test",
+                Route = mockRoute.Object
             };
 
             mockHttpParameterDescriptor.Setup(p => p.IsOptional)
@@ -165,7 +172,8 @@ namespace RAMLSharp.Test
             sampleDescription = new FakeApiDescription(parameterDescriptions)
             {
                 HttpMethod = new System.Net.Http.HttpMethod("get"),
-                RelativePath = "api/test"
+                RelativePath = "api/test",
+                Route = mockRoute.Object
             };
 
             mockHttpParameterDescriptor.Setup(p => p.IsOptional)
@@ -201,7 +209,8 @@ namespace RAMLSharp.Test
             sampleDescription = new FakeApiDescription(parameterDescriptions)
             {
                 HttpMethod = new System.Net.Http.HttpMethod("get"),
-                RelativePath = "api/test"
+                RelativePath = "api/test",
+                Route = mockRoute.Object
             };
             
             sampleApiParameterDescription.ParameterDescriptor = null;
@@ -225,7 +234,8 @@ namespace RAMLSharp.Test
             sampleDescription = new FakeApiDescription(parameterDescriptions)
             {
                 HttpMethod = new System.Net.Http.HttpMethod("get"),
-                RelativePath = "api/test"
+                RelativePath = "api/test",
+                Route = mockRoute.Object
             };
 
             mockHttpParameterDescriptor.Setup(p => p.IsOptional)

--- a/RAMLSharp/Models/RamlModel.cs
+++ b/RAMLSharp/Models/RamlModel.cs
@@ -34,7 +34,7 @@ namespace RAMLSharp.Models
         /// A list of routes, or in an API's case, a list of resources in the API.
         /// </summary>
         public IList<RouteModel> Routes { get; set; }
-
+        
         /// <summary>
         /// This is used to output RAML from the RAMLModel.
         /// </summary>
@@ -80,7 +80,8 @@ namespace RAMLSharp.Models
 
             return RAML.Append(rootString);
         }
-
+        
+        private Dictionary<string, bool> hasVisitedRoutes;
         private StringBuilder SetRamlBody(StringBuilder RAML)
         {
             if (Routes == null || Routes.Count == 0) return RAML;
@@ -91,6 +92,8 @@ namespace RAMLSharp.Models
             foreach (var urls in routeGrouping)
             {
                 RAML = SetResources(RAML, urls);
+
+                hasVisitedRoutes = new Dictionary<string, bool>();
                 RAML = urls.Verbs.Aggregate(RAML, SetRoutes);
             }
 
@@ -107,7 +110,12 @@ namespace RAMLSharp.Models
 
         private StringBuilder SetRoutes(StringBuilder RAML, RouteModel route)
         {
-            RAML = SetUriParameters(RAML, route);
+            if (!hasVisitedRoutes.ContainsKey(route.UrlTemplate) || !hasVisitedRoutes[route.UrlTemplate])
+            {
+                RAML = SetUriParameters(RAML, route);
+                hasVisitedRoutes.Add(route.UrlTemplate, true);
+            }
+
             RAML = SetHttpVerb(RAML, route);
             RAML = SetDescription(RAML, route);
             RAML = SetRequest(RAML, route);

--- a/RAMLSharp/Properties/AssemblyInfo.cs
+++ b/RAMLSharp/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.4.0")]
-[assembly: AssemblyFileVersion("1.0.4.0")]
+[assembly: AssemblyVersion("1.0.5.0")]
+[assembly: AssemblyFileVersion("1.0.5.0")]

--- a/RAMLSharp/RamlMapper.cs
+++ b/RAMLSharp/RamlMapper.cs
@@ -66,9 +66,9 @@ namespace RAMLSharp
                 var routeModel = new RouteModel
                 {
                     Verb = api.HttpMethod.Method.ToLower(),
-                    UrlTemplate = api.RelativePath,
+                    UrlTemplate = api.Route.RouteTemplate,
                     Headers = GetHeaders(headers),
-                    //QueryParameters = GetQueryParameters(api),
+                    QueryParameters = GetQueryParameters(api),
                     BodyParameters = GetBodyParameters(api),
                     UriParameters = GetUriParameters(api),
                     Responses = GetResponseBodies(responseBody),
@@ -84,6 +84,58 @@ namespace RAMLSharp
             }
 
             return model;
+        }
+
+        private IList<RequestQueryParameterModel> GetQueryParameters(ApiDescription description)
+        {
+            var result = new List<RequestQueryParameterModel>();
+
+            var complexParameters = description.ParameterDescriptions
+                    .Where(r => r.Source == ApiParameterSource.FromUri)
+                    .Where(r => r.ParameterDescriptor != null)
+                    .Where(r => r.ParameterDescriptor.ParameterType != null)
+                    .Where(r => r.ParameterDescriptor.ParameterType.IsComplexModel())
+                    .Where(r => !description.Route.RouteTemplate.Contains(string.Format("{{{0}}}", r.ParameterDescriptor.ParameterName)))
+                    .Select(s => new
+                    {
+                        Properties = s.ParameterDescriptor.ParameterType.GetProperties(),
+                        IsOptional = s.ParameterDescriptor.IsOptional,
+                        Description = s.Documentation,
+                        Example = s.ParameterDescriptor.DefaultValue == null ? "" : s.ParameterDescriptor.DefaultValue.ToString()
+                    });
+
+            foreach (var parameter in complexParameters)
+            {
+                var temp = parameter.Properties.Select(q => new RequestQueryParameterModel
+                {
+                    Name = q.Name,
+                    Description = parameter.Description,
+                    IsRequired = parameter.IsOptional,
+                    Type = q.PropertyType,
+                    Example = parameter.Example
+                });
+
+                result.AddRange(temp);
+            };
+
+            var notComplexParameters = description.ParameterDescriptions
+                    .Where(r => r.Source == ApiParameterSource.FromUri)
+                    .Where(r => r.ParameterDescriptor != null)
+                    .Where(r => r.ParameterDescriptor.ParameterType != null)
+                    .Where(r => !r.ParameterDescriptor.ParameterType.IsComplexModel())
+                    .Where(r => !description.Route.RouteTemplate.Contains(string.Format("{{{0}}}", r.ParameterDescriptor.ParameterName)))
+                    .Select(q => new RequestQueryParameterModel
+                    {
+                        Name = q.Name,
+                        Description = q.Documentation,
+                        IsRequired = q.ParameterDescriptor.IsOptional,
+                        Type = q.ParameterDescriptor.ParameterType.GetForRealType(),
+                        Example = q.ParameterDescriptor.DefaultValue == null ? "" : q.ParameterDescriptor.DefaultValue.ToString()
+                    });
+
+            result.AddRange(notComplexParameters);
+
+            return result;
         }
 
 
@@ -131,6 +183,7 @@ namespace RAMLSharp
                     .Where(r => r.ParameterDescriptor != null)
                     .Where(r => r.ParameterDescriptor.ParameterType != null)
                     .Where(r => r.ParameterDescriptor.ParameterType.IsComplexModel())
+                    .Where(r => description.Route.RouteTemplate.Contains(string.Format("{{{0}}}", r.ParameterDescriptor.ParameterName)))
                     .Select(s => new
                     {
                         Properties = s.ParameterDescriptor.ParameterType.GetProperties(),
@@ -158,6 +211,7 @@ namespace RAMLSharp
                     .Where(r => r.ParameterDescriptor != null)
                     .Where(r => r.ParameterDescriptor.ParameterType != null)
                     .Where(r => !r.ParameterDescriptor.ParameterType.IsComplexModel())
+                    .Where(r => description.Route.RouteTemplate.Contains(string.Format("{{{0}}}", r.ParameterDescriptor.ParameterName)))
                     .Select(q => new RequestUriParameterModel
                     {
                         Name = q.Name,

--- a/RAMLSharp/RamlMapper.cs
+++ b/RAMLSharp/RamlMapper.cs
@@ -86,6 +86,9 @@ namespace RAMLSharp
             return model;
         }
 
+
+        #region Private Functions.  These are used to parse the data.
+
         private IList<RequestQueryParameterModel> GetQueryParameters(ApiDescription description)
         {
             var result = new List<RequestQueryParameterModel>();
@@ -137,9 +140,6 @@ namespace RAMLSharp
 
             return result;
         }
-
-
-        #region Private Functions.  These are used to parse the data.
 
         private static IList<ResponseModel> GetResponseBodies(IEnumerable<ResponseBodyAttribute> attributes)
         {

--- a/nuget/RamlSharp.nuspec
+++ b/nuget/RamlSharp.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>RamlSharp</id>
-    <version>1.0.4.0</version>
+    <version>1.0.5.0</version>
     <title>RAMLSharp</title>
     <authors>Jorden Lowe, Dominick Aleardi</authors>
     <owners>Quicken Loans</owners>
@@ -11,7 +11,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <summary>Enables WebApi projects to generate their RAML specification.</summary>
     <description>Enables WebApi projects to generate their RAML specification.</description>
-    <releaseNotes>Fixed issue with complex types in URI parameters.  Added xml documenation to the project for intellsense.  Fixed Null Reference Exception on URI Parameters.  Properly Handle Nullable Types.</releaseNotes>
+    <releaseNotes>Fixed issue with complex types in URI parameters.  Added xml documenation to the project for intellsense.  Fixed Null Reference Exception on URI Parameters.  Properly Handle Nullable Types.  Separated out Query String and URI parameters.  Fixed URI duplication.</releaseNotes>
     <copyright>Copyright ©  2015</copyright>
     <tags>webapi raml help pages ramlsharp</tags>
     <dependencies>


### PR DESCRIPTION
Fixed uri duplication by splitting out Query String and URI parameters.  Then used a dictionary to make sure we are only adding URI parameters once.